### PR TITLE
memory-blocks 1.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 
 [![memory-blocks](http://i.imgur.com/m6ToUa4.png)](https://ionicabizau.github.io/memory-blocks/)
 
-# Memory Blocks [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Version](https://img.shields.io/npm/v/memory-blocks.svg)](https://www.npmjs.com/package/memory-blocks) [![Downloads](https://img.shields.io/npm/dt/memory-blocks.svg)](https://www.npmjs.com/package/memory-blocks) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
+# Memory Blocks
+
+ [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![AMA](https://img.shields.io/badge/ask%20me-anything-1abc9c.svg)](https://github.com/IonicaBizau/ama) [![Version](https://img.shields.io/npm/v/memory-blocks.svg)](https://www.npmjs.com/package/memory-blocks) [![Downloads](https://img.shields.io/npm/dt/memory-blocks.svg)](https://www.npmjs.com/package/memory-blocks) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > The old Memory Blocks game (part of the Symantec Game Pack) ported to modern web.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memory-blocks",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "The old Memory Blocks game (part of the Symantec Game Pack) ported to modern web.",
   "main": "lib/index.js",
   "scripts": {
@@ -116,6 +116,7 @@
     "src/",
     "resources/",
     "menu/",
+    "scripts/",
     "cli.js",
     "index.js"
   ]


### PR DESCRIPTION
- Updated the README.md following the new template. :memo:
- Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.
